### PR TITLE
Make HTTPS target group and health check possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To rebuild the EC2 with the most recent AMI, destroy it manually in the AWS Cons
 | stack\_name | Name of the stack, helps delineate between different projects. | `string` | `"stack"` | no |
 | subnet\_id | Subnet id for the EC2 | `string` | n/a | yes |
 | tags | Map of tags, will be added to the common tags local | `map(string)` | `{}` | no |
+| target\_group\_health\_check | Path for the target group health check | `string` | `"/"` | no |
+| target\_group\_ssl | When set to true, the target group of the ec2 and associated health check will be via https, the default is false, which sends http to the target group | `bool` | `false` | no |
 | vpc\_cidr\_block | Cidr block for VPC ingress | `string` | n/a | yes |
 | vpc\_id | VPC that will be used by terraform, this VPC is called via data only, terraform will not attempt to manage the existence of the VPC | `string` | n/a | yes |
 

--- a/target-group-listener-rule.tf
+++ b/target-group-listener-rule.tf
@@ -1,7 +1,7 @@
 resource "aws_alb_target_group" "target_group" {
   name     = "${local.namespace}-alb-${var.ec2_common_name}"
-  port     = "80"
-  protocol = "HTTP"
+  port     = var.target_group_ssl ? "443" : "80"
+  protocol = var.target_group_ssl ? "HTTPS" : "HTTP"
   vpc_id   = var.vpc_id
 
   stickiness {
@@ -14,8 +14,8 @@ resource "aws_alb_target_group" "target_group" {
     unhealthy_threshold = 10
     timeout             = 5
     interval            = 30
-    path                = "/"
-    port                = "80"
+    path                = var.target_group_health_check
+    port                = var.target_group_ssl ? "443" : "80"
   }
 }
 
@@ -40,5 +40,5 @@ resource "aws_lb_listener_rule" "alb_web_listener_rule" {
 resource "aws_alb_target_group_attachment" "alb_ec2" {
   target_group_arn = aws_alb_target_group.target_group.arn
   target_id        = aws_instance.ec2.id
-  port             = 80
+  port             = var.target_group_ssl ? 443 : 80
 }

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,16 @@ variable "stack_name" {
   description = "Name of the stack, helps delineate between different projects."
 }
 
+variable "target_group_health_check" {
+  default = "/"
+  description = "Path for the target group health check"
+}
+
+variable "target_group_ssl" {
+  default = false
+  description = "When set to true, the target group of the ec2 and associated health check will be via https, the default is false, which sends http to the target group"
+}
+
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
This commit will replace the hard coded HTTP values, allowing
https to be sent to the ec2 target group if desired.